### PR TITLE
Fixing geth ethash

### DIFF
--- a/apps/el-gen/genesis_geth.py
+++ b/apps/el-gen/genesis_geth.py
@@ -44,6 +44,7 @@ else:
             "londonBlock":0,
             "mergeForkBlock":0,
             "terminalTotalDifficulty":0,
+            "terminalTotalDifficultyPassed": true,
             "shanghaiTime": 0,
         },
         "alloc": {


### PR DESCRIPTION
the new field fixes a crash on geth that occurs without it