### PR TITLE
feat: Added support for all 'alloc' fields in EL premine addresses

### DIFF
--- a/apps/el-gen/genesis_besu.py
+++ b/apps/el-gen/genesis_besu.py
@@ -116,10 +116,36 @@ else:
         out["alloc"][acct.address] = {"balance": weival}
 
 
-        # Some hardcoded addrs
-    for key, value in data['el_premine_addrs'].items():
-        weival = value.replace('ETH', '0' * 18)
-        out["alloc"][key] = {"balance": weival}
+    # Some hardcoded addrs
+    for addr, account in data['el_premine_addrs'].items():
+        # Convert balance format
+        if isinstance(account, dict) and 'balance' in account:
+            balance_value = account['balance'].replace('ETH', '0' * 18)
+        else:
+            # If it's not a dictionary, assume it's a single value for backward compatibility
+            balance_value = account.replace('ETH', '0' * 18)
+
+        # Create alloc dictionary entry
+        alloc_entry = {"balance": balance_value}
+
+        # Optionally add code
+        if 'code' in account:
+            alloc_entry['code'] = account['code']
+
+        # Optionally add storage
+        if 'storage' in account:
+            alloc_entry['storage'] = account['storage']
+
+        # Optionally set nonce
+        if 'nonce' in account:
+            alloc_entry['nonce'] = account['nonce']
+
+        # Optionally set private key
+        if 'secretKey' in account:
+            alloc_entry['secretKey'] = account['secretKey']
+
+        # Add alloc entry to output's alloc field
+        out["alloc"][addr] = alloc_entry
 
 out['config']['ethash'] =  {}
 out['config']['cancunTime'] =  int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['deneb_fork_epoch']) * 32 * int(data['slot_duration_in_seconds']))

--- a/apps/el-gen/genesis_chainspec.py
+++ b/apps/el-gen/genesis_chainspec.py
@@ -154,9 +154,35 @@ else:
         out["accounts"][acct.address] = {"balance": weival}
 
     # Some hardcoded addrs
-    for key, value in data['el_premine_addrs'].items():
-        weival = value.replace('ETH', '0' * 18)
-        out["accounts"][key] = {"balance": weival}
+    for addr, account in data['el_premine_addrs'].items():
+        # Convert balance format
+        if isinstance(account, dict) and 'balance' in account:
+            balance_value = account['balance'].replace('ETH', '0' * 18)
+        else:
+            # If it's not a dictionary, assume it's a single value for backward compatibility
+            balance_value = account.replace('ETH', '0' * 18)
+
+        # Create alloc dictionary entry
+        alloc_entry = {"balance": balance_value}
+
+        # Optionally add code
+        if 'code' in account:
+            alloc_entry['code'] = account['code']
+
+        # Optionally add storage
+        if 'storage' in account:
+            alloc_entry['storage'] = account['storage']
+
+        # Optionally set nonce
+        if 'nonce' in account:
+            alloc_entry['nonce'] = account['nonce']
+
+        # Optionally set private key
+        if 'secretKey' in account:
+            alloc_entry['secretKey'] = account['secretKey']
+
+        # Add alloc entry to output's alloc field
+        out["accounts"][addr] = alloc_entry
 
 out['params']['eip4844TransitionTimestamp']= hex(int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['deneb_fork_epoch']) * 32 * int(data['slot_duration_in_seconds'])))
 out['params']['eip4788TransitionTimestamp']= hex(int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['deneb_fork_epoch']) * 32 * int(data['slot_duration_in_seconds'])))

--- a/apps/el-gen/genesis_geth.py
+++ b/apps/el-gen/genesis_geth.py
@@ -116,9 +116,36 @@ else:
         out["alloc"][acct.address] = {"balance": weival}
 
     # Some hardcoded addrs
-    for key, value in data['el_premine_addrs'].items():
-        weival = value.replace('ETH', '0' * 18)
-        out["alloc"][key] = {"balance": weival}
+    for addr, account in data['el_premine_addrs'].items():
+        # Convert balance format
+        if isinstance(account, dict) and 'balance' in account:
+            balance_value = account['balance'].replace('ETH', '0' * 18)
+        else:
+            # If it's not a dictionary, assume it's a single value for backward compatibility
+            balance_value = account.replace('ETH', '0' * 18)
+
+        # Create alloc dictionary entry
+        alloc_entry = {"balance": balance_value}
+
+        # Optionally add code
+        if 'code' in account:
+            alloc_entry['code'] = account['code']
+
+        # Optionally add storage
+        if 'storage' in account:
+            alloc_entry['storage'] = account['storage']
+
+        # Optionally set nonce
+        if 'nonce' in account:
+            alloc_entry['nonce'] = account['nonce']
+
+        # Optionally set private key
+        if 'secretKey' in account:
+            alloc_entry['secretKey'] = account['secretKey']
+
+        # Add alloc entry to output's alloc field
+        out["alloc"][addr] = alloc_entry
+
 
 out['config']['cancunTime'] = int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['deneb_fork_epoch']) * 32 * int(data['slot_duration_in_seconds']))
 print(json.dumps(out, indent='  '))


### PR DESCRIPTION
I've made a few updates; now, it can support both alloc configuration formats:

Retain the original format:

```
el_premine_addrs: {
  "0x123463a4B065722E99115D6c222f267d9cABb524": "1ETH"
}
```

Or use the full format:

```
el_premine_addrs: {
  "0x123463a4B065722E99115D6c222f267d9cABb524": {
    balance: "1ETH",
    code: "0x",
    storage: {},
    nonce: 0,
    secretKey: "0x"
  }
}
```
What do you think about it?