### PR TITLE
Only set pragueTime if electra_fork_epoch is set

### DIFF
--- a/apps/el-gen/genesis_besu.py
+++ b/apps/el-gen/genesis_besu.py
@@ -149,6 +149,11 @@ else:
         # Add alloc entry to output's alloc field
         out["alloc"][addr] = alloc_entry
 
-out['config']['pragueTime'] = int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds']))
+if 'electra_fork_epoch' in data:
+    out['config']['pragueTime'] = \
+        int(data['genesis_timestamp']) + \
+        int(data['genesis_delay']) + \
+        (int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds']))
+
 out['config']['ethash'] =  {}
 print(json.dumps(out, indent='  '))

--- a/apps/el-gen/genesis_chainspec.py
+++ b/apps/el-gen/genesis_chainspec.py
@@ -190,5 +190,11 @@ else:
         # Add alloc entry to output's alloc field
         out["accounts"][addr] = alloc_entry
 
-out['params']['eip6800TransitionTimestamp']= hex(int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds'])))
+if 'electra_fork_epoch' in data:
+    out['params']['eip6800TransitionTimestamp']= hex(
+        int(data['genesis_timestamp']) +
+        int(data['genesis_delay']) +
+        int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds'])
+    )
+
 print(json.dumps(out, indent='  '))

--- a/apps/el-gen/genesis_geth.py
+++ b/apps/el-gen/genesis_geth.py
@@ -148,5 +148,10 @@ else:
         # Add alloc entry to output's alloc field
         out["alloc"][addr] = alloc_entry
 
-out['config']['pragueTime'] = int(data['genesis_timestamp']) + int(data['genesis_delay']) + (int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds']))
+if 'electra_fork_epoch' in data:
+    out['config']['pragueTime'] = \
+        int(data['genesis_timestamp']) + \
+        int(data['genesis_delay']) + \
+        int(data['electra_fork_epoch']) * ( 32 if data['preset_base']=='mainnet' else 8 ) * int(data['slot_duration_in_seconds'])
+
 print(json.dumps(out, indent='  '))


### PR DESCRIPTION
As the latest fork is Deneb, it shouldn't be assumed that test chains are already configuring Electra.
Currently the code will break if `electra_fork_epoch` isn't set, effectively forcing the EL config to set `pragueTime`.