### PR TITLE
Allow env var to define custom contracts

### DIFF
--- a/config-example/el/genesis-config.yaml
+++ b/config-example/el/genesis-config.yaml
@@ -24,7 +24,7 @@ el_premine:
   "m/44'/60'/0'/0/18": 1000000000ETH
   "m/44'/60'/0'/0/19": 1000000000ETH
   "m/44'/60'/0'/0/20": 1000000000ETH
-el_premine_addrs: {}
+el_premine_addrs: ${EL_PRELOADED_CONTRACTS}
 genesis_timestamp: ${GENESIS_TIMESTAMP}
 genesis_delay: ${GENESIS_DELAY}
 genesis_gaslimit: ${GENESIS_GASLIMIT}

--- a/config-example/values.env
+++ b/config-example/values.env
@@ -34,3 +34,15 @@ export SAMPLES_PER_SLOT=8
 export CUSTODY_REQUIREMENT=1
 export DATA_COLUMN_SIDECAR_SUBNET_COUNT=32
 export TARGET_NUMBER_OF_PEERS=70
+export EL_PRELOADED_CONTRACTS='{}'
+# export EL_PRELOADED_CONTRACTS='{
+#  "0x123463a4B065722E99115D6c222f267d9cABb524": {
+#    "balance": "1ETH",
+#    "code": "0x",
+#    "storage": {},
+#    "nonce": 0,
+#    "secretKey": "0x"
+#  }
+#}'
+
+


### PR DESCRIPTION
The default would be: `export EL_PRELOADED_CONTRACTS='{}'`

But defining the variable as: 
```
export EL_PRELOADED_CONTRACTS='{
  "0x123463a4B065722E99115D6c222f267d9cABb524": {
    "balance": "1ETH",
    "code": "0x12",
    "storage": {},
    "nonce": 0,
    "secretKey": "0x"
  }
}'
```
Would add a contract at `0x123463a4B065722E99115D6c222f267d9cABb524` with code `0x12` and balance `1ETH`. 

This feature is useful for defining custom contracts at genesis, especially at times where the contract isn't canonical and doesn't need to exist in all of our releases. An example is if we were to have a L2 kurtosis package, the kurtosis package could define the contracts in the genesis_constants.star file and the expected L2 contracts would exist at genesis on the package. 