### PR TITLE
Add support for large preloads and premines

### DIFF
--- a/apps/el-gen/envsubst.py
+++ b/apps/el-gen/envsubst.py
@@ -1,0 +1,23 @@
+import os
+import re
+import sys
+
+from dotenv import dotenv_values
+
+config = dotenv_values(os.environ['FULL_ENV_FILE'])
+
+bracket_sub_re = re.compile(r'\${(\w+)}')
+basic_sub_re = re.compile(r'\$([A-Z0-9_]+)')
+
+
+def sub(m):
+    cfg = config.get(m.group(1), None)
+    if cfg is None:
+        raise Exception(f"Missing environment variable {m.group(1)}")
+    return cfg
+
+
+for line in sys.stdin:
+    out = bracket_sub_re.sub(sub, line)
+    out = basic_sub_re.sub(sub, out)
+    sys.stdout.write(out)

--- a/apps/el-gen/requirements.txt
+++ b/apps/el-gen/requirements.txt
@@ -1,3 +1,4 @@
 ruamel.yaml==0.17.16
 web3>=6.15.0
 setuptools>=69.1.0
+python-dotenv==1.0.1


### PR DESCRIPTION
We're using the Kurtosis Ethereum package to deploy chains in testing. Some of these chains have large numbers of preloaded contracts and premine addresses. Since the preloads and premines are loaded into the entrypoint via env vars, they can sometimes overflow the maximum arg space available to Bash and cause 'Argument list too long' errors. This PR removes the preloads/premines from the env file so that the script can proceed as originally intend, and implements a custom envsubst script in Python for use with execution layer genesis generation.
