### PR TITLE
Fail complete tag on failed jobs

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -22,7 +22,6 @@ jobs:
     needs:
       - prepare
     runs-on: ${{ matrix.runner }}
-    continue-on-error: true
     strategy:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}


### PR DESCRIPTION
Fixes CI such that the whole release fails if one of the architectures fails. Today the ARM release build had failed and i assumed the whole tag pushed since the CI was green, I updated eth-pkg and it ended up failing a downstream ARM tests as the image was missing. IMO the full CI should have failed since ARM had failed, this PR achieves that. 