### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -32,14 +32,14 @@ runs:
   using: composite
   steps:
   - name: Checkout this repo
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   - name: Set up Docker Context for Buildx
     shell: bash
     id: buildx-context
     run: |
       docker context use builders || docker context create builders
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     with:
       endpoint: builders
   - name: Unlock MacOS keychain for Docker Hub login
@@ -48,7 +48,7 @@ runs:
     run: |
       security -v unlock-keychain -p ${{ inputs.MACOS_PASSWORD }} ~/Library/Keychains/login.keychain-db
   - name: Login to Docker Hub
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}
@@ -61,7 +61,7 @@ runs:
       echo "${{ inputs.tag }}"
   - name: Docker build & push
     id: docker_build
-    uses: docker/build-push-action@v5
+    uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
     with:
       context: '.'
       file: Dockerfile

--- a/.github/actions/manifest/action.yaml
+++ b/.github/actions/manifest/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
   - name: Checkout this repo
-    uses: actions/checkout@v4
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
   - name: Generate images list
     id: generate_images_list
     shell: bash
@@ -58,11 +58,11 @@ runs:
     run: |
       docker context create builders
   - name: Set up Docker Buildx
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
     with:
       endpoint: builders
   - name: Login to Docker Hub
-    uses: docker/login-action@v3
+    uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
     with:
       username: ${{ inputs.DOCKER_USERNAME }}
       password: ${{ inputs.DOCKER_PASSWORD }}

--- a/.github/actions/prepare/action.yaml
+++ b/.github/actions/prepare/action.yaml
@@ -11,8 +11,8 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    - uses: mikefarah/yq@v4.35.1
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: mikefarah/yq@6609ed76ecb69f9d8254345292d90ea72f641715 # v4.35.1
     - name: Generate platform and runner matrix from config files
       id: setup_platforms
       shell: bash
@@ -32,7 +32,7 @@ runs:
         echo "platforms=$PLATFORMS_JSON" >> $GITHUB_OUTPUT
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
       with:
         images: ethpandaops/ethereum-genesis-generator
         flavor: latest=auto

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -14,7 +14,7 @@ jobs:
       platforms: ${{ steps.setup.outputs.platforms }}
       tag: ${{ steps.setup.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Prepare Matrix
         id: setup
         uses: ./.github/actions/prepare
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include: ${{fromJson(needs.prepare.outputs.platforms)}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/deploy
         with:
           platform: ${{ matrix.platform }}
@@ -39,7 +39,7 @@ jobs:
       - deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/manifest
         with:
           tag: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.