### PR TITLE
fix: hex typo

### DIFF
--- a/apps/el-gen/generate_genesis.sh
+++ b/apps/el-gen/generate_genesis.sh
@@ -396,7 +396,7 @@ genesis_add_fulu() {
         "osaka": {
             "target": '"$TARGET_BLOBS_PER_BLOCK_ELECTRA"',
             "max": '"$MAX_BLOBS_PER_BLOCK_ELECTRA"',
-            "baseFeeUpdateFraction": '"$basefee_update_fraction_electra_hex"'
+            "baseFeeUpdateFraction": "'$basefee_update_fraction_electra_hex'"
         }
     }'
 


### PR DESCRIPTION
Fixes bugs like:
```sh
Caused by: Run sh returned exit code '3' that is not part of the acceptable status codes '[0]', with output:
    "+ '[' -f /data/metadata/genesis.json ']'\n+ mkdir -p /data/metadata\n+ source /apps/el-gen/generate_genesis.sh\n+ generate_genesis /data/metadata\n+ set +x\nAdding bellatrix genesis properties\nAdding capella genesis properties\nAdding deneb genesis properties\nAdding electra genesis properties\nAdding fulu genesis properties\njq: error: syntax error, unexpected IDENT, expecting '}' (Unix shell quoting issues?) at <top-level>, line 5:\n            \"baseFeeUpdateFraction\": 0x4c6964                                      \njq: 1 compile error\n"
```