### PR TITLE
Pin eth-beacon-genesis to v0.0.1 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
 FROM golang:1.26 AS builder
 WORKDIR /work
-RUN git clone https://github.com/ethpandaops/eth-beacon-genesis.git  \
-    && cd eth-beacon-genesis && make \
+ARG ETH_BEACON_GENESIS_VERSION=v0.0.1
+ARG ETH_BEACON_GENESIS_SHA=2515c422570d0ba780d5f64d6d284c63845e3666
+RUN git clone -q https://github.com/ethpandaops/eth-beacon-genesis.git \
+    && cd eth-beacon-genesis \
+    && git checkout -q ${ETH_BEACON_GENESIS_VERSION} \
+    && actual_sha=$(git rev-parse HEAD) \
+    && [ "${actual_sha}" = "${ETH_BEACON_GENESIS_SHA}" ] || { \
+         echo "eth-beacon-genesis ${ETH_BEACON_GENESIS_VERSION} resolved to ${actual_sha}, expected ${ETH_BEACON_GENESIS_SHA}" >&2; \
+         exit 1; \
+       } \
+    && make \
     && go install github.com/protolambda/eth2-val-tools@latest \
     && go install github.com/miguelmota/go-ethereum-hdwallet/cmd/geth-hdwallet@latest
 


### PR DESCRIPTION
## Summary

Pin the `eth-beacon-genesis` clone to the immutable tag `v0.0.1` (commit `2515c42…`) via a build `ARG`, and validate the resolved SHA against a pinned value so a maliciously moved tag cannot go unnoticed.

This is a stopgap. Once eth-beacon-genesis is installable via `go install` — i.e. once its current `replace github.com/ethereum/go-ethereum => …` directive can be dropped (which needs upstream go-ethereum to release a tag containing the Amsterdam `BlockAccessListHash` fix) — the Dockerfile should switch to `go install github.com/ethpandaops/eth-beacon-genesis/cmd/eth-genesis-state-generator@vX.Y.Z` for real immutability without any `git clone`.

## Why this matters now

Cloning a moving ref (`master`) from a Dockerfile is vulnerable to Docker layer caching in CI. `.github/actions/deploy/action.yaml` uses:
```yaml
cache-from: type=gha,scope=build-${{ steps.vars.outputs.slug }}
cache-to:   type=gha,scope=build-${{ steps.vars.outputs.slug }},mode=max
```
and because the `RUN git clone …` instruction text does not change between builds, buildx reuses the cached layer. Image rebuilds after `eth-beacon-genesis` master moves forward silently ship a stale clone.

Concrete observed failure: the `:master` and `:6.0.0` images on Docker Hub pushed 2026-04-21 09:02:37 / 09:02:46 UTC still contain `eth-beacon-genesis git-e0f027a` (2026-04-01):

```
$ docker run --rm --entrypoint=/usr/local/bin/eth-genesis-state-generator \
    ethpandaops/ethereum-genesis-generator:master version
eth-beacon-genesis version git-e0f027a
```

…despite being pushed 16 minutes after the Amsterdam `BlockAccessListHash` fix landed at `eth-beacon-genesis` commit `2515c42` on master (2026-04-21 08:46:07 UTC). The pre-fix binary produces CL genesis states whose `latest_block_hash` / `latest_execution_payload_bid.block_hash` do not match what Amsterdam-aware geth computes (`0x9c081ad2…` vs `0x80d3ab13…`), and the chain cannot progress past genesis — the EL keeps responding `SYNCING` to FCUs on an unknown head.

## Change

- Two build ARGs:
  - `ETH_BEACON_GENESIS_VERSION` (default `v0.0.1`) — the human-readable ref that actually gets checked out.
  - `ETH_BEACON_GENESIS_SHA` (default `2515c422570d0ba780d5f64d6d284c63845e3666`) — the SHA we expect that ref to resolve to.
- After `git checkout ${ETH_BEACON_GENESIS_VERSION}` we run `git rev-parse HEAD` and compare. Mismatch → fail the build immediately.
- Bumping either ARG value invalidates the `RUN` layer cache automatically, so future releases take effect in rebuilt images without needing `--no-cache`. Overrides at build time via `--build-arg ETH_BEACON_GENESIS_VERSION=vX.Y.Z --build-arg ETH_BEACON_GENESIS_SHA=<sha>`.

## Test plan

- [x] Pushed eth-beacon-genesis `v0.0.1` tag at `2515c42…`: https://github.com/ethpandaops/eth-beacon-genesis/releases/tag/v0.0.1
- [x] Confirmed `go install github.com/ethpandaops/eth-beacon-genesis/cmd/eth-genesis-state-generator@v0.0.1` currently fails because of the `replace` directive, so we can't switch to that path yet.
- [ ] CI builds a fresh image from this PR and pushes to Docker Hub.
- [ ] `docker run --rm --entrypoint=/usr/local/bin/eth-genesis-state-generator ethpandaops/ethereum-genesis-generator:<pr-tag> version` reports `git-2515c42` instead of `git-e0f027a`.
- [ ] CL genesis state regenerated from that image reports EL genesis hash matching what Amsterdam-aware geth computes for the same `genesis.json` (`0x9c081ad25748d6002940407734c20779cfb5b56709bf94d90590eaf1a04a3e90` for the reference config).