### PR TITLE
feat: add EIP-7976 and EIP-7981 transition timestamps for Nethermind

### DIFF
--- a/apps/el-gen/generate_genesis.sh
+++ b/apps/el-gen/generate_genesis.sh
@@ -839,7 +839,7 @@ genesis_add_bpos() {
 }
 
 # Adds Gloas (Amsterdam) fork properties to genesis files
-# Enabled EIPs: 7708, 7778, 7843, 7928, 7954, 8024, 8037
+# Enabled EIPs: 7708, 7778, 7843, 7928, 7954, 7976, 7981, 8024, 8037
 # Args:
 #   $1: Temporary directory containing genesis files
 genesis_add_gloas() {
@@ -864,6 +864,8 @@ genesis_add_gloas() {
         "eip7843TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7928TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7954TransitionTimestamp": "'$amsterdam_time_hex'",
+        "eip7976TransitionTimestamp": "'$amsterdam_time_hex'",
+        "eip7981TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip8024TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip8037TransitionTimestamp": "'$amsterdam_time_hex'"
     }'


### PR DESCRIPTION
## Summary

Adds two missing Nethermind chainspec transition timestamps for bal-devnet-4 EIPs, both activated at the Gloas/Amsterdam fork timestamp:

- `eip7976TransitionTimestamp` — EIP-7976: Increase Calldata Floor Cost (64/64)
- `eip7981TransitionTimestamp` — EIP-7981: Increase Access List Cost

## Why

Nethermind already reads both keys in `ChainSpecParamsJson.cs` and toggles `IsEip7976Enabled` / `IsEip7981Enabled` from them in `ChainSpecBasedSpecProvider`. Without these fields in the generated chainspec, Nethermind runs Amsterdam without the new calldata-floor and access-list gas rules and diverges from clients (e.g. geth) that activate both EIPs at the Amsterdam fork timestamp.

Same pattern as #269 (EIP-7954/EIP-8037) and #262 (earlier Gloas EIPs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)