### PR TITLE
Pin eth-beacon-genesis to v0.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM golang:1.26 AS builder
 WORKDIR /work
-ARG ETH_BEACON_GENESIS_SHA=bddffdc436768de180e653c526a89a6172773149
+ARG ETH_BEACON_GENESIS_VERSION=v0.0.2
+ARG ETH_BEACON_GENESIS_SHA=340b63dda66afe1cbaa4b8cbc3044b56f7290d6d
 RUN git clone -q https://github.com/ethpandaops/eth-beacon-genesis.git \
     && cd eth-beacon-genesis \
-    && git checkout -q ${ETH_BEACON_GENESIS_SHA} \
+    && git checkout -q ${ETH_BEACON_GENESIS_VERSION} \
+    && actual_sha=$(git rev-parse HEAD) \
+    && [ "${actual_sha}" = "${ETH_BEACON_GENESIS_SHA}" ] || { \
+         echo "eth-beacon-genesis ${ETH_BEACON_GENESIS_VERSION} resolved to ${actual_sha}, expected ${ETH_BEACON_GENESIS_SHA}" >&2; \
+         exit 1; \
+       } \
     && make \
     && go install github.com/protolambda/eth2-val-tools@latest \
     && go install github.com/miguelmota/go-ethereum-hdwallet/cmd/geth-hdwallet@latest


### PR DESCRIPTION
## Summary
- Bumps the \`eth-beacon-genesis\` clone from a free-floating SHA (\`bddffdc\`) to the immutable [\`v0.0.2\`](https://github.com/ethpandaops/eth-beacon-genesis/releases/tag/v0.0.2) tag at commit \`340b63d\`.
- Restores the \`ETH_BEACON_GENESIS_VERSION\` arg and the SHA cross-check originally introduced in [#285](https://github.com/ethpandaops/ethereum-genesis-generator/pull/285) — they were dropped in [#287](https://github.com/ethpandaops/ethereum-genesis-generator/pull/287) only because no tagged release contained the gloas genesis fix at the time.

## What's in v0.0.2
- Minimal-preset \`PTC_SIZE\` bumped from 2 to 16, matching consensus-specs alpha 6 ([#5177](https://github.com/ethereum/consensus-specs/pull/5177)).
- \`go-eth2-client\` v0.1.0 → v0.1.1.
- Includes the gloas-genesis empty-parent fix that the previous SHA was already at.

## Test plan
- [x] Dockerfile diff is the only change.
- [ ] \`docker build .\` against this branch should succeed; the SHA-vs-tag cross-check inside the \`RUN\` layer fails the build immediately if \`v0.0.2\` ever gets re-tagged to a different commit.