### PR TITLE
chore: bump eth-beacon-genesis to v0.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26 AS builder
 WORKDIR /work
-ARG ETH_BEACON_GENESIS_VERSION=v0.0.2
-ARG ETH_BEACON_GENESIS_SHA=340b63dda66afe1cbaa4b8cbc3044b56f7290d6d
+ARG ETH_BEACON_GENESIS_VERSION=v0.0.3
+ARG ETH_BEACON_GENESIS_SHA=ec3e0f719f7a56fd28ca775a4b9acd231f5e32c6
 RUN git clone -q https://github.com/ethpandaops/eth-beacon-genesis.git \
     && cd eth-beacon-genesis \
     && git checkout -q ${ETH_BEACON_GENESIS_VERSION} \


### PR DESCRIPTION
## Summary
- Bump pinned `eth-beacon-genesis` version from `v0.0.2` → `v0.0.3` (and update the SHA pin to match) to pull in the PTC_SIZE bump and go-eth2-client v0.1.1.

## Test plan
- [x] `docker build .` succeeds and the resulting image's `eth-genesis-state-generator` runs against the existing config-example.

## Notes
Considered switching from `git clone` + `make` to a single `go install …@v0.0.3`, but `eth-beacon-genesis`'s `go.mod` has a `replace` directive (forked `go-ethereum`), and Go refuses to `install` a module with replace directives. Keeping the clone-based build.