### PR TITLE
feat(el-gen): predeploy well-known contracts (create2 factory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Type | Name | Description
 `0x02` | Compounding | Like `0x01` but enables reward compounding. Effective balance can grow up to `MAX_EFFECTIVE_BALANCE_ELECTRA` (2048 ETH). Requires Electra or later.
 `0x03` | Builder | Identifies a builder validator (EIP-7732 ePBS). Same address structure as `0x01`/`0x02`. Builders participate in the decentralized block auction mechanism. Requires EIP-7732 or later.
 
+### Well-known contracts
+
+Chain-agnostic contracts that live at the same address on (nearly) every EVM chain — such as the deterministic deployment / CREATE2 proxy (`0x4e59…956C`) — are predeployed into genesis automatically. They are inert until called, so downstream tooling (and any CREATE2 address derived from them) works out of the box on a fresh devnet, without relying on a keyless bootstrap transaction.
+
+The set is data-driven from [`apps/el-gen/well-known-contracts.yaml`](apps/el-gen/well-known-contracts.yaml) — add a contract by appending an entry there, no code change needed. Toggle the feature with `PRELOAD_WELL_KNOWN_CONTRACTS` (default `true`). An `ADDITIONAL_PRELOADED_CONTRACTS` entry for the same address still overrides the default.
+
 ### Shadow Fork
 If shadow fork from file is the preferred option, then please ensure the latest block `json` response is collected along with
 transactions. This can be done with the below call for example:

--- a/apps/el-gen/generate_genesis.sh
+++ b/apps/el-gen/generate_genesis.sh
@@ -87,6 +87,11 @@ generate_genesis() {
         # Add system contracts
         genesis_add_system_contracts $tmp_dir
 
+        # Add well-known, chain-agnostic contracts (deterministic deployment
+        # proxy, etc.). Placed before premine/additional contracts so explicit
+        # config can still override them.
+        genesis_add_well_known_contracts $tmp_dir
+
         # Build complete allocations object before applying
         if [ -f /config/el/genesis-config.yaml ]; then
             envsubst < /config/el/genesis-config.yaml | yq -c > $tmp_dir/el-genesis-config.json
@@ -545,6 +550,33 @@ genesis_add_system_contracts() {
         echo -e "  EIP-7251 contract:\t$target_address"
         genesis_add_allocation $tmp_dir $target_address $(echo "$system_contracts" | jq -c '.eip7251')
     fi
+}
+
+# Deploys well-known, chain-agnostic contracts that are expected at the same
+# address on (nearly) every EVM chain, e.g. the deterministic deployment /
+# CREATE2 proxy. The contracts are inert until called, so predeploying them is
+# safe. Controlled by PRELOAD_WELL_KNOWN_CONTRACTS (default: true); the contract
+# set is data-driven from apps/el-gen/well-known-contracts.yaml, so adding a new
+# one needs no code change here.
+# Args:
+#   $1: Temporary directory for storing allocations
+genesis_add_well_known_contracts() {
+    local tmp_dir=$1
+
+    if [ "${PRELOAD_WELL_KNOWN_CONTRACTS:-true}" != "true" ]; then
+        echo "Skipping well-known contracts (PRELOAD_WELL_KNOWN_CONTRACTS=${PRELOAD_WELL_KNOWN_CONTRACTS:-true})"
+        return
+    fi
+
+    local well_known_contracts=$(cat /apps/el-gen/well-known-contracts.yaml | yq -c)
+
+    echo "Adding well-known contracts"
+    for name in $(echo "$well_known_contracts" | jq -r 'keys[]'); do
+        local target_address=$(echo "$well_known_contracts" | jq -r --arg n "$name" '.[$n].address')
+        local allocation=$(echo "$well_known_contracts" | jq -c --arg n "$name" '.[$n] | del(.address)')
+        echo -e "  $name:\t$target_address"
+        genesis_add_allocation $tmp_dir "$target_address" "$allocation"
+    done
 }
 
 # Adds Bellatrix (Merge) fork properties to genesis files

--- a/apps/el-gen/well-known-contracts.yaml
+++ b/apps/el-gen/well-known-contracts.yaml
@@ -1,0 +1,30 @@
+# Well-known contracts
+#
+# Chain-agnostic contracts that live at the SAME address on (nearly) every EVM
+# chain and that downstream tooling expects to already exist. They are inert
+# until called, so predeploying them is safe and lets contracts and tools that
+# depend on them work out-of-the-box on a fresh devnet.
+#
+# Toggle with PRELOAD_WELL_KNOWN_CONTRACTS (default: true).
+# Add a contract by appending an entry below -- no code change required. Each
+# entry is a friendly name mapping to an `address` plus a standard allocation
+# body (`code`, and optionally `nonce`, `balance`, `storage`).
+
+# Deterministic deployment proxy -- "Nick's factory" / Arachnid CREATE2 factory
+# (https://github.com/Arachnid/deterministic-deployment-proxy). Normally
+# bootstrapped by a keyless, fixed-gas transaction; that bootstrap can no longer
+# be mined on chains whose contract-creation intrinsic gas exceeds the keyless
+# tx's fixed gas limit, so predeploying it guarantees the canonical 0x4e59...
+# factory (and every CREATE2 address derived from it) is available.
+deterministic_deployment_proxy: {
+  "address": "0x4e59b44847b379578588920cA78FbF26c0B4956C",
+  "balance": "0",
+  "nonce": "1",
+  "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+}
+
+# Further candidates -- add as standalone entries when needed (verify the exact
+# runtime code and canonical address for each before adding):
+#   eip2470_singleton_factory  0xce0042B868300000d44A59004Da54A005ffdcf9f
+#   multicall3                 0xcA11bde05977b3631167028862bE2a173976CA11
+#   createx                    0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed

--- a/defaults/defaults.env
+++ b/defaults/defaults.env
@@ -75,6 +75,7 @@ export EL_PREMINE_COUNT="${EL_PREMINE_COUNT:-21}" # Number of premine accounts t
 export EL_PREMINE_BALANCE="${EL_PREMINE_BALANCE:-1000000000ETH}" # Balance for each premine account
 export EL_PREMINE_ADDRS="${EL_PREMINE_ADDRS:-"{}"}" # {"0x1000000000000000000000000000000000000000": {"balance": "10ETH"}}
 export ADDITIONAL_PRELOADED_CONTRACTS="${ADDITIONAL_PRELOADED_CONTRACTS:-"{}"}" # {"0x0000000000000000000000000000000000000000": {"balance": "1ETH","code": "0x123465","storage": {},"nonce": 0,"secretKey": "0x"}}
+export PRELOAD_WELL_KNOWN_CONTRACTS="${PRELOAD_WELL_KNOWN_CONTRACTS:-true}" # Predeploy the chain-agnostic contracts in apps/el-gen/well-known-contracts.yaml (e.g. the deterministic deployment / CREATE2 proxy). Set to "false" to disable.
 export SECONDS_PER_ETH1_BLOCK="${SECONDS_PER_ETH1_BLOCK:-14}"
 export FULU_MAX_BLOBS_PER_TX="${FULU_MAX_BLOBS_PER_TX:-0}"
 export BPO_1_EPOCH="${BPO_1_EPOCH:-18446744073709551615}"


### PR DESCRIPTION
Adds a small, data-driven way to predeploy well-known contracts that live at the same address across (almost) all EVM chains. New manifest `apps/el-gen/well-known-contracts.yaml` (starting with the CREATE2 deployer proxy at `0x4e59…956C`) gets merged into the EL alloc via `genesis_add_well_known_contracts()`, mirroring `genesis_add_system_contracts()`.

On by default (`PRELOAD_WELL_KNOWN_CONTRACTS`), and adding more is just one manifest entry. Keeps the canonical CREATE2 factory available on chains where the old keyless deploy tx can't be mined anymore (e.g. Glamsterdam devnets where EIP-8037 pushes the cost for the original create2 factory above 100k which is the tx.gaslimit), so no need to hand-add the bytecode via `ADDITIONAL_PRELOADED_CONTRACTS`.

It's inert until called, and `ADDITIONAL_PRELOADED_CONTRACTS` still wins for the same address.