### PR TITLE
feat(el-gen): add missing glamsterdam-devnet-6 chainspec EIPs

### DIFF
--- a/apps/el-gen/generate_genesis.sh
+++ b/apps/el-gen/generate_genesis.sh
@@ -883,7 +883,7 @@ genesis_add_bpos() {
 }
 
 # Adds Gloas (Amsterdam) fork properties to genesis files
-# Enabled EIPs: 7708, 7778, 7843, 7928, 7954, 7976, 7981, 8024, 8037
+# Enabled EIPs: 2780, 7708, 7778, 7843, 7928, 7954, 7976, 7981, 8024, 8037, 8038, 8246, 8282
 # Args:
 #   $1: Temporary directory containing genesis files
 genesis_add_gloas() {
@@ -903,6 +903,7 @@ genesis_add_gloas() {
 
     # chainspec.json
     genesis_add_json $tmp_dir/chainspec.json '.params += {
+        "eip2780TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7708TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7778TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7843TransitionTimestamp": "'$amsterdam_time_hex'",
@@ -911,7 +912,10 @@ genesis_add_gloas() {
         "eip7976TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip7981TransitionTimestamp": "'$amsterdam_time_hex'",
         "eip8024TransitionTimestamp": "'$amsterdam_time_hex'",
-        "eip8037TransitionTimestamp": "'$amsterdam_time_hex'"
+        "eip8037TransitionTimestamp": "'$amsterdam_time_hex'",
+        "eip8038TransitionTimestamp": "'$amsterdam_time_hex'",
+        "eip8246TransitionTimestamp": "'$amsterdam_time_hex'",
+        "eip8282TransitionTimestamp": "'$amsterdam_time_hex'"
     }'
 
     # besu.json


### PR DESCRIPTION
## What

Adds the missing EL-execution EIP transition flags to the **gloas/amsterdam** chainspec block (`genesis_add_gloas` in `apps/el-gen/generate_genesis.sh`) for [glamsterdam-devnet-6](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-6).

Only `chainspec.json` (Nethermind/Erigon-style) enumerates per-EIP transition timestamps — `genesis.json` (geth) and `besu.json` activate via the named `amsterdamTime`, so no change is needed there.

## Added flags

| EIP | Title |
|---|---|
| `eip2780` | Reduce intrinsic transaction gas |
| `eip8038` | State-access gas cost update |
| `eip8246` | Remove SELFDESTRUCT Burn |
| `eip8282` | Builder execution requests (request types `0x03`/`0x04`) |

`eip8282` mirrors how Electra's request contracts (7002/7251) each get a chainspec flag alongside their predeploy. The 8282 predeploys themselves landed in #297; this wires up the activation flag.

## Intentionally excluded

These devnet-6 EIPs are **not** chainspec transition flags:
- **7997** – Deterministic Factory: a genesis predeploy (well-known contract), not a flag
- **7732** – Enshrined PBS: the fork headliner itself
- **7975 / 8159 / 8070** – eth/70, 71, 72 devp2p wire protocol (networking-only)
- **8045 / 8061** – consensus-layer only

## Notes for reviewers

- The exact key `eip8282TransitionTimestamp` is inferred from the 7002/7251 naming convention — the devnet-6 notes didn't publish an explicit chainspec snippet. Worth confirming against the EL client implementations.
- `bash -n` passes; the remaining 9 amsterdam flags are unchanged.