### PR TITLE
chore: bump eth-beacon-genesis to v0.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26 AS builder
 WORKDIR /work
-ARG ETH_BEACON_GENESIS_VERSION=v0.0.4
-ARG ETH_BEACON_GENESIS_SHA=6d60dcf20a9faffb5e4a0b819b661e6a4e08a9b4
+ARG ETH_BEACON_GENESIS_VERSION=v0.0.5
+ARG ETH_BEACON_GENESIS_SHA=899ec78e492f1761a40712f5bdf8841c3fefd1af
 RUN git clone -q https://github.com/ethpandaops/eth-beacon-genesis.git \
     && cd eth-beacon-genesis \
     && git checkout -q ${ETH_BEACON_GENESIS_VERSION} \


### PR DESCRIPTION
Bumps the bundled `eth-beacon-genesis` build from **v0.0.4 → v0.0.5**.

- `ETH_BEACON_GENESIS_VERSION`: `v0.0.4` → `v0.0.5`
- `ETH_BEACON_GENESIS_SHA`: `6d60dcf20a9faffb5e4a0b819b661e6a4e08a9b4` → `899ec78e492f1761a40712f5bdf8841c3fefd1af`

v0.0.5 brings in the recently merged dependency work on eth-beacon-genesis:
- go-eth2-client v0.1.5 (with the `BaseFeePerGasLE` and gloas `ExecutionRequests` API adaptations)
- urfave/cli v3.10.0 and golang.org/x/sync v0.21.0

The pinned SHA is eth-beacon-genesis `master` HEAD, where v0.0.5 is being cut.

> [!NOTE]
> This requires the `v0.0.5` tag to be pushed on eth-beacon-genesis at commit `899ec78` before the Docker build can succeed — the Dockerfile verifies the checked-out tag resolves to the expected SHA and fails otherwise.