### PR TITLE
Change builder withdrawal prefix from 0x03 to 0xB0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Type | Name | Description
 `0x00` | BLS withdrawal | Credentials derived from the validator's BLS withdrawal key. No execution address required. Validators must rotate to `0x01` or higher before withdrawals can be processed.
 `0x01` | Execution withdrawal | Credentials pointing to an execution layer address. Enables partial and full withdrawals to the specified address. Effective balance is capped at 32 ETH.
 `0x02` | Compounding | Like `0x01` but enables reward compounding. Effective balance can grow up to `MAX_EFFECTIVE_BALANCE_ELECTRA` (2048 ETH). Requires Electra or later.
-`0x03` | Builder | Identifies a builder validator (EIP-7732 ePBS). Same address structure as `0x01`/`0x02`. Builders participate in the decentralized block auction mechanism. Requires EIP-7732 or later.
+`0xB0` | Builder | Identifies a builder validator (EIP-7732 ePBS). Same address structure as `0x01`/`0x02`. Builders participate in the decentralized block auction mechanism. Requires EIP-7732 or later.
 
 ### Well-known contracts
 

--- a/config-example/cl/mnemonics.yaml
+++ b/config-example/cl/mnemonics.yaml
@@ -3,6 +3,6 @@
   start: 0  # account index to start from
   count: $NUMBER_OF_VALIDATORS
   wd_address: $WITHDRAWAL_ADDRESS
-  wd_prefix: $WITHDRAWAL_TYPE  # 0x00=BLS, 0x01=execution address, 0x02=compounding, 0x03=builder (EIP-7732)
+  wd_prefix: $WITHDRAWAL_TYPE  # 0x00=BLS, 0x01=execution address, 0x02=compounding, 0xB0=builder (EIP-7732)
   balance: $VALIDATOR_BALANCE
   status: 0 # 0: active, 1: slashed, 2: exited


### PR DESCRIPTION
ethereum/consensus-specs#5416 (merged, lands in v1.7.0-alpha.12) changed `BUILDER_WITHDRAWAL_PREFIX` from `0x03` to `0xB0`. This updates the builder withdrawal-credential prefix references accordingly:

- `README.md`: withdrawal-credential type table row `0x03` -> `0xB0`
- `config-example/cl/mnemonics.yaml`: `wd_prefix` comment `0x03=builder` -> `0xB0=builder`

Not changed (different namespace): EIP-8282 deposit **request type** `0x03` references in `apps/el-gen/system-contracts.yaml` and `apps/el-gen/generate_genesis.sh`.

No code in this repo validates or switches on specific `wd_prefix` values — `entrypoint.sh` only special-cases `0x00` (to null out `WITHDRAWAL_ADDRESS`), and the `DEPOSIT_CONTRACT_SETTINGS` handling in `generate_genesis.sh` accepts arbitrary `0x00`-`0xff` prefix keys, so `0xB0` works as-is.