### PR TITLE
Emit eip8141TransitionTimestamp into the nethermind chainspec for bogota

### DIFF
--- a/apps/el-gen/generate_genesis.sh
+++ b/apps/el-gen/generate_genesis.sh
@@ -930,7 +930,7 @@ genesis_add_gloas() {
 }
 
 # Adds Bogota (Heze) fork properties to genesis files
-# Enabled EIPs: 7805
+# Enabled EIPs: 7805, 8141
 # Args:
 #   $1: Temporary directory containing genesis files
 genesis_add_heze() {
@@ -950,7 +950,8 @@ genesis_add_heze() {
 
     # chainspec.json
     genesis_add_json $tmp_dir/chainspec.json '.params += {
-        "eip7805TransitionTimestamp": "'$bogota_time_hex'"
+        "eip7805TransitionTimestamp": "'$bogota_time_hex'",
+        "eip8141TransitionTimestamp": "'$bogota_time_hex'"
     }'
 
     # besu.json


### PR DESCRIPTION
Emit `eip8141TransitionTimestamp` into the nethermind chainspec alongside `eip7805TransitionTimestamp` in `genesis_add_heze`, using the same bogota activation time. Nethermind loads `chainspec.json` rather than the geth-style genesis, so without this key EIP-8141 never activates there even when `bogotaTime` is set (details in #306).

Harmless for nethermind builds that don't know the key — the chainspec loader ignores unknown params. If you'd rather gate it behind its own toggle instead of bundling it into bogota, happy to rework.

Closes #306
